### PR TITLE
Use SuperNEMO logo for site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
   <div class="wrapper">
 
     <!-- Dummy add of icon for now - replace with SVG of experiment logo -->
-    <a class="site-title" href="{{ "/" | relative_url}}"><span class="icon">{% include icon-github.svg %}</span> {{ site.title | escape }}</a>
+    <a class="site-title" href="{{ "/" | relative_url}}"><span class="icon"><img src="{{ "assets/supernemo_logo_v1.0.png" | relative_url}}" alt="SuperNEMO Logo" height=26px></span> {{ site.title | escape }}</a>
 
     <nav class="site-nav">
       <span class="menu-icon">


### PR DESCRIPTION
Replace placeholder logo with official collaboration logo in site header. Use png file now for simplicity, matching height in px to that for header text.