### PR TITLE
Add and document target for updating Gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ running
 $ ./snjekyll help
 ```
 
+## Updating Jekyll and Dependencies
+
+Whilst [Bundler][http://bundler.io] is used to provide a consistent fixed version of
+Jekyll and its dependencies, these require updating from time to time. The `snjekyll`
+script provides a `update-gems` target which can be built to perform the update task.
+The output of this is an updated version of the `Gemfile.lock` file. To avoid issues
+with git/other changes, the required add/commit of this file, if changed, must be
+done manually, e.g.
+
+```console
+$ ./snjekyll update-gems
+[snjekyll]: Updating Gems...
+... output from bundler...
+Bundle updated!
+[snjekyll]: Updated gems, Gemfile.lock status:
+M Gemfile.lock
+[snjekyll]: If the above status shows 'M', please commit Gemfile.lock and submit a Pull Request
+$
+$ git add Gemfile.lock
+$ git commit -m "Gems and Gemfile.lock updated to latest versions"
+```
+
+The new commit should then be submitted as a normal Pull Request.
+
 ## Known Issues
 - No reliable check for existence of `ruby-dev{el}` package on Linuces
   - Will issue a warning, but nothing more

--- a/snjekyll
+++ b/snjekyll
@@ -8,24 +8,35 @@
 #
 define USAGE
 usage: ./snjekyll <task>
+
 Setup, build and serve a Jekyll based website on a local computer.
 Requires an installation of Ruby, including the Ruby development library
 and headers.
 
 Available tasks:
   setup          Install RubyGem requirements into current working directory
+
   build          Build the site using `jekyll build`
-	test           Test the built site using `htmlproofer`
-	               Note that this can only be run after a direct build
-								 and will not work in `serve` mode yet.
+
+  test           Test the built site using `htmlproofer`
+                 Note that this can only be run after a direct build
+                 and will not work in `serve` mode yet.
+
   serve          Start a non-detached local jekyll server instance
                  The site can be viewed at 'http://127.0.0.1:4000' in
                  your favoured browser. The server will watch for changes
                  to the site files and rebuild automatically. Simply
                  refresh your browser to pick up the changes.
+
+  update-gems    Update installed gems and Gemfile.lock.
+                 If the Gemfile.lock file changes, it must be submitted as a PR.
+
   clean-gems     Remove local bundle of gems
+
   clean-site     Remove local site generated output and metadata
+
   clean          Remove both gems and site
+
   help           Print this message
 
 endef
@@ -143,6 +154,16 @@ $(JEKYLL_EXEC): $(BUNDLE_EXEC) Gemfile Gemfile.lock
 
 # Setup local tools
 setup: $(JEKYLL_EXEC)
+
+# Update Gemfile
+# See http://bundler.io/v1.16/man/bundle-update.1.html
+# Warn user that Gemfile.lock must be commited
+update-gems: setup
+	@echo "[snjekyll]: Updating Gems..."
+	@$(BUNDLE_EXEC) update
+	@echo "[snjekyll]: Updated gems, Gemfile.lock status:"
+	@echo `git status -s Gemfile.lock`
+	@echo "[snjekyll]: If the above status shows 'M', please commit Gemfile.lock and submit a Pull Request"
 
 # Explicit site clean
 clean-site:


### PR DESCRIPTION
As reported in #66, Github helpfully warns about significant issues
in Gem versions in the lock file.

To help updating Gem dependencies, add an `update-gems` target in
the makefile to automate the update and regenerate Gemfile.lock.
Do not auto-commit changes to avoid clashes.

Update README with info on running this target and committing changes.

No changes to Gemfile.lock are done yet.